### PR TITLE
Implement fallback bucket (WORK IN PROGRESS)

### DIFF
--- a/Plugins/S3Reader2/S3File.cs
+++ b/Plugins/S3Reader2/S3File.cs
@@ -130,6 +130,11 @@ namespace ImageResizer.Plugins.S3Reader2 {
         public string GetCacheKey(bool includeModifiedDate) {
             return VirtualPath + (includeModifiedDate ? ("_" + ModifiedDateUTC.Ticks.ToString()) : "");
         }
+
+        public string GetBucket()
+        {
+            return bucket;
+        }
     }
 }
 

--- a/Plugins/S3Reader2/S3Reader.cs
+++ b/Plugins/S3Reader2/S3Reader.cs
@@ -16,7 +16,7 @@ using ImageResizer.Configuration.Xml;
 namespace ImageResizer.Plugins.S3Reader2 {
     public class S3Reader2 : IPlugin, IMultiInstancePlugin, IRedactDiagnostics {
 
-        string buckets, vpath;
+        string buckets, vpath, fallbackBucket;
         bool includeModifiedDate = false;
         bool asVpp = false;
         AmazonS3Config s3config = null;
@@ -25,6 +25,7 @@ namespace ImageResizer.Plugins.S3Reader2 {
             s3config = new AmazonS3Config();
 
             buckets = args["buckets"];
+            fallbackBucket = args["fallback"];
             vpath = args["prefix"];
 
             asVpp = NameValueCollectionExtensions.Get(args, "vpp", true);
@@ -126,11 +127,10 @@ namespace ImageResizer.Plugins.S3Reader2 {
             for (int i = 0; i < bucketArray.Length; i++)
                 bucketArray[i] = bucketArray[i].Trim();
 
-
             vpp = new S3VirtualPathProvider(this.S3Client, vpath,TimeSpan.MaxValue, new TimeSpan(0, 1, 0, 0),  delegate(S3VirtualPathProvider s, S3PathEventArgs ev) {
                 if (bucketArray == null) ev.ThrowException();
                 ev.AssertBucketMatches(bucketArray);
-            }, !includeModifiedDate);
+            }, !includeModifiedDate, fallbackBucket);
 
             
 

--- a/Plugins/S3Reader2/S3Reader.cs
+++ b/Plugins/S3Reader2/S3Reader.cs
@@ -119,10 +119,17 @@ namespace ImageResizer.Plugins.S3Reader2 {
             if (string.IsNullOrEmpty(vpath)) vpath = "~/s3/";
 
             string[] bucketArray = null;
-            if (!string.IsNullOrEmpty(buckets)) bucketArray = buckets.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            if (!string.IsNullOrEmpty(buckets))
+                bucketArray = buckets.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             else c.configurationSectionIssues.AcceptIssue(new Issue("S3Reader", "S3Reader cannot function without a list of permitted bucket names.",
                 "Please specify a comma-delimited list of buckets in the <add name='S3Reader' buckets='bucketa,bucketb' /> element.",
                  IssueSeverity.ConfigurationError));
+
+            // add the fallbackBucket to the array
+            if (!string.IsNullOrEmpty(fallbackBucket))
+            {
+                bucketArray = new List<string>(bucketArray) {fallbackBucket}.ToArray();
+            }
 
             for (int i = 0; i < bucketArray.Length; i++)
                 bucketArray[i] = bucketArray[i].Trim();

--- a/Plugins/S3Reader2/S3VirtualPathProvider.cs
+++ b/Plugins/S3Reader2/S3VirtualPathProvider.cs
@@ -167,12 +167,14 @@ namespace ImageResizer.Plugins.S3Reader2
         private S3File GetS3File(string virtualPath)
         {
             var file = new S3File(virtualPath, this);
-            if (!file.Exists && string.IsNullOrEmpty(FallbackBucket))
-            {
-                var fallbackVirtualPath = virtualPath.Replace(file.GetBucket(), FallbackBucket);
-                return new S3File(fallbackVirtualPath, this);
-            }
+            if (!file.Exists && !string.IsNullOrEmpty(FallbackBucket))
+                return new S3File(GetFallbackVirtualPath(file), this);
             return file;
+        }
+
+        private string GetFallbackVirtualPath(S3File file)
+        {
+            return file.VirtualPath.Replace(file.GetBucket(), FallbackBucket);
         }
 
         /**


### PR DESCRIPTION
Customize the logic of the S3Reader plugin in ImageResizer so it will try to load the image from this second bucket if not exists on the first one

### Issues
Right now I just added code for trying to load the image from the fallback if doesn't exists, but it assumes that the `accessKeyId` and the `secretAccessKey` are the same between both buckets. I'm not sure if that is possible. 
On the web.config of lodgify-images the values are differents, so I need to know if its posible, becuase if not i will need to add configuration params for the keys on the fallback.
I still need acces to AWS to create a valid credentials on 2 buckets so I can test...

### Test cases
* Image exists on primary bucket - will load the image from primary
* Image doesn't exists on primary, exists on fallback, will load the image from the fallback
* Image doesn't exists at all - 404?

